### PR TITLE
BLD: require python 3.8, drop dependency on importlib-metadata

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -14,6 +14,7 @@ url = https://pypi.org/project/deptree/
 
 
 [options]
+python_requires = >=3.8
 package_dir =
     = src
 packages = find:

--- a/src/deptree/_meta.py
+++ b/src/deptree/_meta.py
@@ -3,13 +3,13 @@
 """ Meta information
 """
 
-import importlib_metadata
+import importlib.metadata
 
 PROJECT_NAME = 'deptree'
 
 
 def _get_metadata():
-    return importlib_metadata.metadata(PROJECT_NAME)
+    return importlib.metadata.metadata(PROJECT_NAME)
 
 
 def get_summary():


### PR DESCRIPTION
Hi, thank you for building this tool
I was using it to find out wether any of my installed packages had `setuptools` declared as a runtime dependency and found out that... this tool does !
This can be an issue because `import setuptools` has side effects that make debugging harder in some instances (e.g., it modifies `sys.path` so `import distutils` doesn't load from the standard library)

Anyway, `deptree` doesn't actually need `setuptools` at runtime so the fix is straight-forward.

I also found that the other (real) runtime dependency, `importlib_metadata` is not necessary for Python 3.8 and newer, so I added the corresponding metadata.

Last, I found that `python_requires` wasn't set. It's good practice to use this piece of metadata so the program doesn't crash on known-too-old version of the interpreter with `SyntaxError`s
~I set it arbitrarily to Python 3.7 (because it's currently the oldest version that still has support from the PSF), but feel free to change it.~

edit: changed to Python 3.6 as it appears to be the oldest *tested* version

