### PR TITLE
Remove testing against Python 3.6

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,10 +9,6 @@
     - 'python3 -m tox'
     - 'python3 -m tox -e package'
 
-'review py36':
-  extends: '.review'
-  image: 'python:3.6'
-
 'review py37':
   extends: '.review'
   image: 'python:3.7'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ dist: 'xenial'
 language: 'python'
 
 python:
-  - '3.6'
   - '3.7'
   - '3.8'
   - '3.9'
@@ -14,7 +13,6 @@ python:
 
 jobs:
   allow_failures:
-    - python: '3.6'  # There are issues with 'cryptography'
     - python: '3.10-dev'
   fast_finish: true
 

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,6 @@
 
 [tox]
 envlist =
-    py36
     py37
     py38
     py39


### PR DESCRIPTION
Python 3.6 reached its end of life some time ago.