### PR TITLE
Use `license_files` in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,8 @@ author = sinoroc
 author_email = sinoroc.code+python@gmail.com
 description = Display installed Python projects as a tree of dependencies
 license = Apache-2.0
-license_file = LICENSE.txt
+license_files =
+    LICENSE.txt
 long_description = file: README.rst
 long_description_content_type = text/x-rst
 name = deptree


### PR DESCRIPTION
The field `license_file` is now deprecated.