### PR TITLE
Update list of Pythons tested against

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,9 +22,12 @@
   image: 'python:3.9'
 
 'review py310':
-  allow_failure: true
   extends: '.review'
-  image: 'python:3.10-rc'
+  image: 'python:3.10'
+
+'review py311':
+  extends: '.review'
+  image: 'python:3.11'
 
 
 ... EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,19 @@
 ---
 
 
-dist: 'xenial'
+dist: 'bionic'
 
 language: 'python'
+
+os:
+    - 'linux'
 
 python:
   - '3.7'
   - '3.8'
   - '3.9'
-  - '3.10-dev'
-
-jobs:
-  allow_failures:
-    - python: '3.10-dev'
-  fast_finish: true
+  - '3.10'
+  - '3.11'
 
 install:
   - 'python3 -m pip install tox tox-travis'
@@ -30,14 +29,14 @@ deploy:
     file: 'dist/*'
     skip_cleanup: true
     on:
-      python: '3.9'
+      python: '3.7'
       tags: true
   - provider: 'pypi'
     distributions: 'sdist bdist_wheel'
     user: '${PYPI_USER}'
     password: '${PYPI_PASSWORD}'
     on:
-      python: '3.9'
+      python: '3.7'
       tags: true
 
 sudo: false

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,8 @@
 0.0.11.dev0
 ===========
 
+* Supported Python versions 3.7 to 3.11
+
 
 0.0.10
 ======

--- a/tox.ini
+++ b/tox.ini
@@ -6,23 +6,19 @@ envlist =
     py37
     py38
     py39
+    py310
+    py311
 isolated_build = True
 
 
 [testenv]
 commands =
-    py39: make review
-    !py39: make test
+    py37: make review
+    !py37: make test
 extras =
     dev_test
 allowlist_externals =
     make
-
-
-[testenv:py310]
-description = Outcome is ignored since Python 3.10 is not released yet
-#
-ignore_outcome = True
 
 
 [testenv:package]
@@ -33,7 +29,7 @@ extras =
 
 
 [testenv:develop]
-basepython = python3.9
+basepython = python3.7
 description = Activate this environment for interactive development
 #
 commands =


### PR DESCRIPTION
Test against Python 3.7 to 3.11, and use the oldest (3.7) as default, assuming if it works with the oldest it should work with the others.