### PR TITLE
Rewrite handling of project's own metadata

### DIFF
--- a/src/deptree/__init__.py
+++ b/src/deptree/__init__.py
@@ -6,6 +6,4 @@
 from . import _meta
 from . import cli
 
-__version__ = _meta.VERSION  # PEP 396
-
 # EOF

--- a/src/deptree/_meta.py
+++ b/src/deptree/_meta.py
@@ -7,9 +7,21 @@ import importlib_metadata
 
 PROJECT_NAME = 'deptree'
 
-_DISTRIBUTION_METADATA = importlib_metadata.metadata(PROJECT_NAME)
 
-SUMMARY = _DISTRIBUTION_METADATA['Summary']
-VERSION = _DISTRIBUTION_METADATA['Version']
+def _get_metadata():
+    return importlib_metadata.metadata(PROJECT_NAME)
+
+
+def get_summary():
+    """Get project's summary."""
+    metadata = _get_metadata()
+    return metadata['Summary']
+
+
+def get_version():
+    """Get project's version string."""
+    metadata = _get_metadata()
+    return metadata['Version']
+
 
 # EOF

--- a/src/deptree/cli.py
+++ b/src/deptree/cli.py
@@ -17,12 +17,12 @@ def main():
     """
     args_parser = argparse.ArgumentParser(
         allow_abbrev=False,
-        description=_meta.SUMMARY,
+        description=_meta.get_summary(),
     )
     args_parser.add_argument(
         '--version',
         action='version',
-        version=_meta.VERSION,
+        version=_meta.get_version(),
     )
     args_parser.add_argument(
         '-r',

--- a/test/test_unit.py
+++ b/test/test_unit.py
@@ -6,19 +6,6 @@ import unittest
 import deptree
 
 
-class TestProjectVersion(unittest.TestCase):
-    """ Project version string
-    """
-
-    def test_project_has_version_string(self):
-        """ Project should have a vesion string
-        """
-        try:
-            deptree.__version__
-        except AttributeError as version_exception:
-            self.fail(version_exception)
-
-
 class TestSelectType(unittest.TestCase):
     """Selection type"""
 


### PR DESCRIPTION
Remove the PEP 396 `__version__`.
Delay loading of project's own metadata until requested.