### PR TITLE
Use `python` instead of `python3`

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,11 +3,11 @@
 
 '.review':
   before_script:
-    - 'python3 -m pip install tox'
+    - 'python -m pip install tox'
   script:
     - 'export TOXENV="${CI_JOB_NAME##review}"'
-    - 'python3 -m tox'
-    - 'python3 -m tox -e package'
+    - 'python -m tox'
+    - 'python -m tox -e package'
 
 'review py37':
   extends: '.review'
@@ -30,4 +30,4 @@
   image: 'python:3.11'
 
 
-... EOF
+...  # EOF

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,11 @@ python:
   - '3.11'
 
 install:
-  - 'python3 -m pip install tox tox-travis'
+  - 'python -m pip install tox tox-travis'
 
 script:
-  - 'python3 -m tox'
-  - 'python3 -m tox -e package'
+  - 'python -m tox'
+  - 'python -m tox -e package'
 
 deploy:
   - provider: 'releases'
@@ -42,4 +42,4 @@ deploy:
 sudo: false
 
 
-... EOF
+...  # EOF

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ tests_dir := ./test
 
 .PHONY: develop
 develop:
-	python3 setup.py develop
+	python setup.py develop
 
 
 .PHONY: package
@@ -19,49 +19,49 @@ package: sdist wheel zapp
 
 .PHONY: sdist
 sdist:
-	python3 setup.py sdist
-	python3 -m twine check dist/*.tar.gz
+	python setup.py sdist
+	python -m twine check dist/*.tar.gz
 
 
 .PHONY: wheel
 wheel:
-	python3 setup.py bdist_wheel
-	python3 -m twine check dist/*.whl
+	python setup.py bdist_wheel
+	python -m twine check dist/*.whl
 
 
 .PHONY: zapp
 zapp:
-	python3 setup.py bdist_zapp
+	python setup.py bdist_zapp
 
 
 .PHONY: format
 format:
-	python3 -m yapf --in-place --parallel --recursive setup.py $(source_dir) $(tests_dir)
+	python -m yapf --in-place --parallel --recursive setup.py $(source_dir) $(tests_dir)
 
 
 .PHONY: check
 check:
-	python3 setup.py check
+	python setup.py check
 
 
 .PHONY: lint
 lint:
-	python3 -m pytest --pycodestyle --pylint --yapf -m 'pycodestyle or pylint or yapf'
+	python -m pytest --pycodestyle --pylint --yapf -m 'pycodestyle or pylint or yapf'
 
 
 .PHONY: pycodestyle
 pycodestyle:
-	python3 -m pytest --pycodestyle -m pycodestyle
+	python -m pytest --pycodestyle -m pycodestyle
 
 
 .PHONY: pylint
 pylint:
-	python3 -m pytest --pylint -m pylint
+	python -m pytest --pylint -m pylint
 
 
 .PHONY: yapf
 yapf:
-	python3 -m pytest --yapf -m yapf
+	python -m pytest --yapf -m yapf
 
 
 .PHONY: test
@@ -70,12 +70,12 @@ test: pytest
 
 .PHONY: pytest
 pytest:
-	python3 -m pytest
+	python -m pytest
 
 
 .PHONY: review
 review: check
-	python3 -m pytest --pycodestyle --pylint --yapf
+	python -m pytest --pycodestyle --pylint --yapf
 
 
 .PHONY: clean

--- a/README.rst
+++ b/README.rst
@@ -125,8 +125,8 @@ For example:
 
 .. code::
 
-    $ python3 -m pip install --target ./deptree/ deptree
-    $ python3 -m zipapp --python '/usr/bin/env python3' --main 'deptree.cli:main' ./deptree/
+    $ python -m pip install --target ./deptree/ deptree
+    $ python -m zipapp --python '/usr/bin/env python' --main 'deptree.cli:main' ./deptree/
     $ mv ./deptree.pyz ~/.local/bin/deptree
 
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """ Setup script """
 


### PR DESCRIPTION
There was a time when being explicit about using Python 3 made sense, but this does not seem to be the case anymore.