### PR TITLE
Remove the usage of *setuptools* `check` command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ editable:
 
 
 .PHONY: package
-package: check sdist wheel zapp
+package: sdist wheel zapp
 
 
 .PHONY: sdist
@@ -37,11 +37,6 @@ zapp:
 .PHONY: format
 format:
 	python -m yapf --in-place --parallel --recursive setup.py $(source_dir) $(tests_dir)
-
-
-.PHONY: check
-check:
-	python setup.py check
 
 
 .PHONY: lint
@@ -74,7 +69,7 @@ pytest:
 
 
 .PHONY: review
-review: check
+review:
 	python -m pytest --pycodestyle --pylint --yapf
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -5,11 +5,6 @@
 entry_point = deptree.cli:main
 
 
-[check]
-metadata = 1
-strict = 1
-
-
 [metadata]
 license_files =
     LICENSE.txt


### PR DESCRIPTION
It seems like the `pyproject.toml` based tooling already takes care of checking that the necessary metadata is present.
Checking the content of the *long description* is done by *twine*.